### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: ShellCheck Lint 🐚


### PR DESCRIPTION
Potential fix for [https://github.com/windows10do/PaternMal/security/code-scanning/2](https://github.com/windows10do/PaternMal/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions:` block to restrict the default `GITHUB_TOKEN` scope to the minimal permissions required. Since this workflow only checks out code and runs local shell commands, it only needs read access to repository contents.

The best way to fix this without changing functionality is to add a single `permissions:` block at the root of the workflow (at the same level as `on:` and `jobs:`). This will apply to all jobs that don’t define their own job-level `permissions`. We can set `contents: read` as recommended. No additional imports or methods are required, because this is a YAML configuration change only. Concretely, in `.github/workflows/install-test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). This keeps the workflow behavior the same while ensuring the `GITHUB_TOKEN` has least-privilege read-only access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
